### PR TITLE
Add typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,11 @@
   "main": "dist/Vueresize.js",
   "files": [
     "dist/Vueresize.js",
-    "dist/Vueresize.js.map"
+    "dist/Vueresize.js.map",
+    "types/index.d.ts",
+    "types/vueresize.d.ts"
   ],
+  "types": "types/index.d.ts",
   "keywords": [
     "vue",
     "vuejs",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,4 @@
+import { VueResizeDirectiveOptions } from "./vueresize";
+
+declare var VueResize: VueResizeDirectiveOptions;
+export default VueResize;

--- a/types/vueresize.d.ts
+++ b/types/vueresize.d.ts
@@ -1,0 +1,4 @@
+import { PluginObject } from "vue";
+import { DirectiveOptions } from "vue/types/options";
+
+export interface VueResizeDirectiveOptions extends DirectiveOptions {}


### PR DESCRIPTION
Fixes #13. Adds a bare minimum type information so that eslint understands this is a vue directive.

My first ever type def for vue, so I'm not sure what other functionality should be exposed in this, but this shuts up the linter and the plugin still works just as expected in a ts project.